### PR TITLE
Corrected SeekEnd behaviour

### DIFF
--- a/writerseeker.go
+++ b/writerseeker.go
@@ -37,7 +37,7 @@ func (ws *WriterSeeker) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		newPos = ws.pos + offs
 	case io.SeekEnd:
-		newPos = len(ws.buf) - offs
+		newPos = len(ws.buf) + offs
 	}
 	if newPos < 0 {
 		return 0, errors.New("negative result pos")

--- a/writerseeker_test.go
+++ b/writerseeker_test.go
@@ -35,7 +35,7 @@ func TestSeek(t *testing.T) {
 		t.Fail()
 	}
 
-	ws.Seek(2, io.SeekEnd)
+	ws.Seek(-2, io.SeekEnd)
 	ws.Write([]byte("k!"))
 	if string(writerSeeker.buf) != "hello work!" {
 		t.Fail()


### PR DESCRIPTION
When calculating the position for SeekEnd, you have to add the offset - just like with SeekSet - not subtract it.

I know, it feels a little counter-intuitive - I've made the exact same mistake a couple of times - but the [docs](http://man7.org/linux/man-pages/man2/lseek.2.html) say to add.